### PR TITLE
[WRD-44] Shared store projection: PlayedWordsLibrary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,6 +492,28 @@ immediately; it is not captured at construction.
 
 ---
 
+## Shared Store Projections
+
+When **multiple surfaces read the same persisted collection**, don't let each call the store's
+`fetchAll()` itself. Introduce **one `.container`-scoped `@Observable` read-projection** over the store —
+the observable window everyone reads.
+
+- **`PlayedWordsLibrary`** (`PlayedWordsLibraryType`, `@Observable`, `.container`) is the projection over
+  `WordStorageModelContextType`: it owns `words`, derived via `load()` at launch (hydrated in
+  `WordayApp.init`) and `reload()` after a change. The **store stays the single source of truth** — the
+  projection only ever derives from it, so the readers can't disagree.
+- **Readers take the projection, not the store.** `WordListViewStateConverter` and `StreakUseCase` read
+  `playedWordsLibrary.words` — never `wordContext.fetchAll()`. Because it's a shared `@Observable`, a
+  change re-renders every reader natively.
+- **The writer owns the store and refreshes the projection.** `WordProviderUseCase` writes through
+  `WordStorageModelContextType` (insert/save) and then calls `playedWordsLibrary.reload()` — a direct
+  call, not a signal. The writer may still read the canonical store directly for its own logic; the
+  projection is for the *display* readers.
+- `.container` scope + `===` in `DependencyGraphTests` (one stable shared instance). A new display reader
+  of the stored words takes `PlayedWordsLibraryType`; a new *store* is given its own projection.
+
+---
+
 ## Networking
 
 The API layer is already fully **async/await** and stays that way:

--- a/Worday/Application/WordayApp.swift
+++ b/Worday/Application/WordayApp.swift
@@ -14,6 +14,10 @@ struct WordayApp: App {
         self.navigationDestinationViewProvider = container.resolve()
         self.modalRouter = container.resolve()
         self.modalDestinationViewProvider = container.resolve()
+
+        // Hydrate the shared played-words projection once at launch; writers reload() it thereafter.
+        let playedWordsLibrary: PlayedWordsLibraryType = container.resolve()
+        playedWordsLibrary.load()
     }
 
     init() {

--- a/Worday/Common/Dependency Injection/CommonDependencies.swift
+++ b/Worday/Common/Dependency Injection/CommonDependencies.swift
@@ -38,5 +38,9 @@ extension ContainerType {
         register(in: .container) { container in
             AttemptTrackerUseCase(userSettings: container.resolve()) as AttemptTrackerUseCaseType
         }
+
+        register(in: .container) { container in
+            PlayedWordsLibrary(wordContext: container.resolve()) as PlayedWordsLibraryType
+        }
     }
 }

--- a/Worday/Storage/PlayedWordsLibrary.swift
+++ b/Worday/Storage/PlayedWordsLibrary.swift
@@ -1,0 +1,40 @@
+import Observation
+
+/// The single observable window onto the player's stored words. A `.container`-scoped `@Observable`
+/// read-projection over `WordStorageModelContextType`: the store stays the source of truth and this only
+/// ever *derives* from it (`load()` at launch, `reload()` after a word is stored), so the display
+/// surfaces that read it — the word list and the streak — can never disagree with each other. Readers
+/// take `PlayedWordsLibraryType` instead of hitting the store directly; the writer
+/// (`WordProviderUseCase`) calls `reload()` after saving.
+@MainActor
+protocol PlayedWordsLibraryType: AnyObject {
+    var words: [WordStorageEntity] { get }
+    func load()
+    func reload()
+}
+
+@Observable
+final class PlayedWordsLibrary: PlayedWordsLibraryType {
+
+    // MARK: - Life Cycle
+
+    init(wordContext: WordStorageModelContextType) {
+        self.wordContext = wordContext
+    }
+
+    // MARK: - Publics
+
+    private(set) var words: [WordStorageEntity] = []
+
+    func load() {
+        reload()
+    }
+
+    func reload() {
+        words = (try? wordContext.fetchAll()) ?? []
+    }
+
+    // MARK: - Privates
+
+    @ObservationIgnored private let wordContext: WordStorageModelContextType
+}

--- a/Worday/Use Cases/StreakUseCase.swift
+++ b/Worday/Use Cases/StreakUseCase.swift
@@ -7,21 +7,20 @@ protocol StreakUseCaseType {
 
 struct StreakUseCase: StreakUseCaseType {
     
-    init(wordContext: WordStorageModelContextType,
+    init(playedWordsLibrary: PlayedWordsLibraryType,
          calendarService: CalendarServiceType) {
-        self.wordContext = wordContext
+        self.playedWordsLibrary = playedWordsLibrary
         self.calendarService = calendarService
     }
-    
+
     func totalPlayed() -> Int {
-        guard let playedDates = try? wordContext.fetchAll() else { return 0 }
-        return playedDates.count
+        playedWordsLibrary.words.count
     }
-    
+
     func calculateStreak() -> Int {
-        // Fetch played dates and check if the user has played yet or not
-        guard let playedDates = try? wordContext.fetchAll().compactMap({ $0.playedAt }),
-                playedDates.isEmpty == false else { return 0 }
+        // Read played dates and check if the user has played yet or not
+        let playedDates = playedWordsLibrary.words.map { $0.playedAt }
+        guard playedDates.isEmpty == false else { return 0 }
         
         // Check if the last played date is today
         guard let lastPlayedDate = playedDates.first,
@@ -52,6 +51,6 @@ struct StreakUseCase: StreakUseCaseType {
     }
     
     // MARK: - Privates
-    private let wordContext: WordStorageModelContextType
+    private let playedWordsLibrary: PlayedWordsLibraryType
     private let calendarService: CalendarServiceType
 }

--- a/Worday/Use Cases/WordDependencies.swift
+++ b/Worday/Use Cases/WordDependencies.swift
@@ -15,12 +15,13 @@ extension ContainerType {
                                 uuidProvider: container.resolve(),
                                 dateProvider: Date(),
                                 finishGameRelay: container.resolve(),
-                                attemptTrackerUseCase: container.resolve())
+                                attemptTrackerUseCase: container.resolve(),
+                                playedWordsLibrary: container.resolve())
             as WordProviderUseCaseType
         }
 
         register { container in
-            StreakUseCase(wordContext: container.resolve(),
+            StreakUseCase(playedWordsLibrary: container.resolve(),
                           calendarService: container.resolve())
             as StreakUseCaseType
         }

--- a/Worday/Use Cases/WordProviderUseCase.swift
+++ b/Worday/Use Cases/WordProviderUseCase.swift
@@ -22,7 +22,8 @@ final class WordProviderUseCase: WordProviderUseCaseType {
         uuidProvider: UUIDProviderType,
         dateProvider: DateProviderType,
         finishGameRelay: FinishGameRelayType,
-        attemptTrackerUseCase: AttemptTrackerUseCaseType
+        attemptTrackerUseCase: AttemptTrackerUseCaseType,
+        playedWordsLibrary: PlayedWordsLibraryType
     ) {
         self.wordRepository = wordRepository
         self.wordContext = wordContext
@@ -33,6 +34,7 @@ final class WordProviderUseCase: WordProviderUseCaseType {
         self.dateProvider = dateProvider
         self.finishGameRelay = finishGameRelay
         self.attemptTrackerUseCase = attemptTrackerUseCase
+        self.playedWordsLibrary = playedWordsLibrary
     }
     
     func fetch() -> FetchWordModel {
@@ -82,6 +84,7 @@ final class WordProviderUseCase: WordProviderUseCaseType {
             )
         )
         try? wordContext.save()
+        playedWordsLibrary.reload()
         userSettings.currentWord = nil
         finishGameRelay.finishGame()
     }
@@ -96,4 +99,5 @@ final class WordProviderUseCase: WordProviderUseCaseType {
     private let dateProvider: DateProviderType
     private let finishGameRelay: FinishGameRelayType
     private let attemptTrackerUseCase: AttemptTrackerUseCaseType
+    private let playedWordsLibrary: PlayedWordsLibraryType
 }

--- a/Worday/Views/ViewDependencies.swift
+++ b/Worday/Views/ViewDependencies.swift
@@ -34,7 +34,7 @@ extension ContainerType {
         }
 
         register { container in
-            WordListViewStateConverter(wordContext: container.resolve(),
+            WordListViewStateConverter(playedWordsLibrary: container.resolve(),
                                        navigationRouter: container.resolve())
             as WordListViewStateConverterType
         }

--- a/Worday/Views/Word List/WordListViewStateConverter.swift
+++ b/Worday/Views/Word List/WordListViewStateConverter.swift
@@ -6,14 +6,14 @@ protocol WordListViewStateConverterType {
 
 struct WordListViewStateConverter: WordListViewStateConverterType {
     
-    init(wordContext: WordStorageModelContextType,
+    init(playedWordsLibrary: PlayedWordsLibraryType,
          navigationRouter: NavigationRouterType) {
-        self.wordContext = wordContext
+        self.playedWordsLibrary = playedWordsLibrary
         self.navigationRouter = navigationRouter
     }
     
     func make() -> WordListViewState {
-        let allWords = (try? self.wordContext.fetchAll()) ?? []
+        let allWords = playedWordsLibrary.words
         let cards: [WordListViewState.Card] = allWords.enumerated()
             .compactMap { index, word in
                 .init(
@@ -33,6 +33,6 @@ struct WordListViewStateConverter: WordListViewStateConverterType {
     }
     
     // MARK: - Privates
-    private let wordContext: WordStorageModelContextType
+    private let playedWordsLibrary: PlayedWordsLibraryType
     private let navigationRouter: NavigationRouterType
 }

--- a/WordayTests/Mocks/PlayedWordsLibraryMock.swift
+++ b/WordayTests/Mocks/PlayedWordsLibraryMock.swift
@@ -1,0 +1,21 @@
+@testable import Worday
+
+final class PlayedWordsLibraryMock: PlayedWordsLibraryType {
+
+    enum Call: Equatable {
+        case load
+        case reload
+    }
+
+    var words: [WordStorageEntity] = []
+
+    func load() {
+        calls.append(.load)
+    }
+
+    func reload() {
+        calls.append(.reload)
+    }
+
+    private(set) var calls: [Call] = []
+}

--- a/WordayTests/Tests/DependencyGraphTests.swift
+++ b/WordayTests/Tests/DependencyGraphTests.swift
@@ -43,6 +43,7 @@ struct DependencyGraphTests {
         _ = container.resolve() as WordMeaningViewModelFactoryType
         _ = container.resolve() as NavigationDestinationViewProviderType
         _ = container.resolve() as ModalDestinationViewProviderType
+        _ = container.resolve() as PlayedWordsLibraryType
     }
 
     @Test("a .container-scoped dependency resolves to the same instance")
@@ -51,6 +52,16 @@ struct DependencyGraphTests {
 
         let first = container.resolve() as HTTPClientType
         let second = container.resolve() as HTTPClientType
+
+        #expect(first === second)
+    }
+
+    @Test("the shared played-words library resolves to the same instance")
+    func playedWordsLibraryIsShared() {
+        let container = makeWiredContainer()
+
+        let first = container.resolve() as PlayedWordsLibraryType
+        let second = container.resolve() as PlayedWordsLibraryType
 
         #expect(first === second)
     }

--- a/WordayTests/Tests/PlayedWordsLibraryTests.swift
+++ b/WordayTests/Tests/PlayedWordsLibraryTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import Worday
+
+struct PlayedWordsLibraryTests {
+    let sut: PlayedWordsLibrary
+    let mockWordContext: WordStorageModelContextMock
+
+    init() {
+        mockWordContext = .init()
+        sut = .init(wordContext: mockWordContext)
+    }
+
+    @Test("load reads the stored words from the context")
+    func loadReadsFromStore() {
+        mockWordContext.fetchReturnValue = [
+            .init(id: "1", word: "CAT", playedAt: .init(timeIntervalSince1970: 0))
+        ]
+
+        sut.load()
+
+        #expect(sut.words.map(\.word) == ["CAT"])
+        #expect(mockWordContext.calls == [.fetchAll])
+    }
+
+    @Test("reload refreshes the words from the context")
+    func reloadRefreshesFromStore() {
+        mockWordContext.fetchReturnValue = []
+        sut.load()
+        #expect(sut.words.isEmpty)
+
+        mockWordContext.fetchReturnValue = [
+            .init(id: "1", word: "DOG", playedAt: .init(timeIntervalSince1970: 0))
+        ]
+        sut.reload()
+
+        #expect(sut.words.map(\.word) == ["DOG"])
+    }
+}

--- a/WordayTests/Tests/StreakUseCaseTests.swift
+++ b/WordayTests/Tests/StreakUseCaseTests.swift
@@ -5,15 +5,15 @@ import Foundation
 struct StreakUseCaseTests {
     
     var sut: StreakUseCase
-    var mockWordContext: WordStorageModelContextMock
+    var mockPlayedWordsLibrary: PlayedWordsLibraryMock
     var mockCalendarService: CalendarServiceMock
-    
+
     init() {
-        mockWordContext = .init()
+        mockPlayedWordsLibrary = .init()
         mockCalendarService = .init()
-        
+
         sut = .init(
-            wordContext: mockWordContext,
+            playedWordsLibrary: mockPlayedWordsLibrary,
             calendarService: mockCalendarService
         )
         
@@ -32,7 +32,7 @@ struct StreakUseCaseTests {
     }
 
     @Test func totalPlayed() async throws {
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "1", word: "abcde", playedAt: .now),
             .init(id: "2", word: "abcde", playedAt: .now),
             .init(id: "3", word: "abcde", playedAt: .now)
@@ -42,7 +42,7 @@ struct StreakUseCaseTests {
     }
     
     @Test func streakConsecutiveDates() async throws {
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "1", word: "abcde", playedAt: date1),
             .init(id: "2", word: "abcde", playedAt: date2),
             .init(id: "3", word: "abcde", playedAt: date3)
@@ -52,7 +52,7 @@ struct StreakUseCaseTests {
     }
     
     @Test func streakPlayedOnce() async throws {
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "1", word: "abcde", playedAt: date1)
         ]
         
@@ -60,7 +60,7 @@ struct StreakUseCaseTests {
     }
     
     @Test func streakNonConsecutiveDates() async throws {
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "1", word: "abcde", playedAt: date1),
             .init(id: "2", word: "abcde", playedAt: date3),
             .init(id: "3", word: "abcde", playedAt: date4)
@@ -70,7 +70,7 @@ struct StreakUseCaseTests {
     }
     
     @Test func streakNotPlayedToday() async throws {
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "2", word: "abcde", playedAt: date3),
             .init(id: "3", word: "abcde", playedAt: date4)
         ]

--- a/WordayTests/Tests/WordListViewStateConverterTests.swift
+++ b/WordayTests/Tests/WordListViewStateConverterTests.swift
@@ -5,20 +5,20 @@ import Foundation
 struct WordListViewStateConverterTests {
     
     let sut: WordListViewStateConverter
-    let mockWordContext: WordStorageModelContextMock
+    let mockPlayedWordsLibrary: PlayedWordsLibraryMock
     let mockNavigationRouter: NavigationRouterMock
 
     init() {
-        mockWordContext = .init()
+        mockPlayedWordsLibrary = .init()
         mockNavigationRouter = .init()
-        sut = .init(wordContext: mockWordContext,
+        sut = .init(playedWordsLibrary: mockPlayedWordsLibrary,
                     navigationRouter: mockNavigationRouter)
     }
 
     @Test func makesViewState() {
         let fakeDate: Date = .init(timeIntervalSince1970: 123)
 
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "1", word: "ABCDE", playedAt: fakeDate),
             .init(id: "2", word: "QWXYZ", playedAt: fakeDate)
         ]
@@ -39,7 +39,7 @@ struct WordListViewStateConverterTests {
     @Test func tapsOnWord() {
         let fakeDate: Date = .init(timeIntervalSince1970: 123)
 
-        mockWordContext.fetchReturnValue = [
+        mockPlayedWordsLibrary.words = [
             .init(id: "1", word: "ABCDE", playedAt: fakeDate),
             .init(id: "2", word: "QWXYZ", playedAt: fakeDate)
         ]

--- a/WordayTests/Tests/WordProviderUseCaseTests.swift
+++ b/WordayTests/Tests/WordProviderUseCaseTests.swift
@@ -14,7 +14,8 @@ struct WordProviderUseCaseTests {
     var mockDateProvider: DateProviderMock
     var mockFinishGameRelay: FinishGameRelayMock
     var mockAttemptTrackerUseCase: AttemptTrackerUseCaseMock
-    
+    var mockPlayedWordsLibrary: PlayedWordsLibraryMock
+
     init() {
         mockWordRepository = .init()
         mockWordContext = .init()
@@ -25,6 +26,7 @@ struct WordProviderUseCaseTests {
         mockDateProvider = .init()
         mockFinishGameRelay = .init()
         mockAttemptTrackerUseCase = .init()
+        mockPlayedWordsLibrary = .init()
         sut = .init(
             wordRepository: mockWordRepository,
             wordContext: mockWordContext,
@@ -34,7 +36,8 @@ struct WordProviderUseCaseTests {
             uuidProvider: mockUUIDProvider,
             dateProvider: mockDateProvider,
             finishGameRelay: mockFinishGameRelay,
-            attemptTrackerUseCase: mockAttemptTrackerUseCase
+            attemptTrackerUseCase: mockAttemptTrackerUseCase,
+            playedWordsLibrary: mockPlayedWordsLibrary
         )
     }
     
@@ -136,6 +139,7 @@ struct WordProviderUseCaseTests {
         sut.store(word: "a")
         #expect(mockUserSettings.setCurrentWordCall == [.currentWord(.set(nil))])
         #expect(mockWordContext.calls == [.insert(model: .init(id: "123", word: "a", playedAt: referenceDate)), .save])
+        #expect(mockPlayedWordsLibrary.calls == [.reload])
         #expect(mockFinishGameRelay.calls == [.finishGame])
     }
 }


### PR DESCRIPTION
**Phase B** of the ProjectPrivacy architecture migration (design in `ProjectPrivacyMigration-Design.md`). Introduces **`PlayedWordsLibrary`** — a `.container`-scoped `@Observable` read-projection over `WordStorageModelContextType` — as the single observable window onto the player's stored words. No behaviour change; **69 tests green**; app verified in the simulator.

## Change
- `StreakUseCase` + `WordListViewStateConverter` read `playedWordsLibrary.words` instead of each calling `wordContext.fetchAll()` independently.
- `WordProviderUseCase` stays the write-owner (insert/save through the context) and calls `playedWordsLibrary.reload()` after saving.
- Hydrated once at launch in `WordayApp.init` via `load()`.
- The store stays the single source of truth; the projection only derives.

## Tests
`PlayedWordsLibraryTests` (load/reload) + `PlayedWordsLibraryMock`; `StreakUseCaseTests` / `WordListViewStateConverterTests` migrated to the library mock; `WordProviderUseCaseTests` asserts `reload()` on store; `DependencyGraphTests` covers the registration + `.container` identity. CLAUDE.md gains a "Shared Store Projections" section.

## Next
C — `EntityID<T>`; D — feature docs + per-feature DI; E — alert host (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)