### PR TITLE
[WRD-46] Feature docs + README architecture (migration wrap-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,38 @@
 - Learn as You Play: Guess the word correctly to unlock its meaning!
 - Daily Challenge: A fresh word puzzle every day to keep you engaged.
 
+## Architecture
+
+A layered, protocol-oriented, dependency-injected **SwiftUI + Swift 6** app (main-actor by default, no
+Combine — `@Observable` and `async/await` throughout):
+
+```
+View  →  ViewModel (@Observable)  →  UseCase  →  Repository  →  Service
+                                                                 ├─ HTTPClient        (network, async/await)
+                                                                 ├─ ResourceLoader    (bundled word list)
+                                                                 └─ ModelContext      (SwiftData history)
+```
+
+- **Screens** are `View + ViewState + ViewModel + Factory`; the view is a dumb function of a computed
+  `viewState`.
+- **Routing** is `router (state) + ViewModifier host + provider` for both navigation and modals
+  (`Navigation Routing/`, `Modal Routing/`).
+- **Persistence** is SwiftData with versioned schemas + a migration plan; display surfaces read the
+  `PlayedWordsLibrary` projection (`Storage/`).
+- **DI** is a small container with per-area registration files aggregated by
+  `Common/Dependency Injection/Dependencies.swift`.
+
+Engineering conventions live in [`CLAUDE.md`](CLAUDE.md); each feature folder carries its own
+`*.md` "how to use" doc.
+
+## Building & testing
+
+The repo uses the full Xcode toolchain. If `xcode-select` points at the Command Line Tools, override it
+per command:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+xcodebuild test -project Worday.xcodeproj -scheme Worday \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+

--- a/Worday/Common/Entity ID/EntityID.md
+++ b/Worday/Common/Entity ID/EntityID.md
@@ -1,0 +1,37 @@
+# EntityID
+
+`EntityID<Entity>` is a phantom-typed identifier — a `String` raw value tagged with the entity it
+identifies — so the compiler stops one entity's id being used where another's belongs.
+
+## What it is
+
+```swift
+nonisolated struct EntityID<Entity>: Hashable, Sendable, Codable {
+    let rawValue: String
+}
+```
+
+- The `Entity` parameter is **compile-time only** — nothing about it is stored; only `rawValue` is
+  encoded. `EntityID<WordStorageEntity>` and `EntityID<SomeOther>` are distinct, incompatible types.
+- **`nonisolated`** because the module is main-actor-by-default but an id is a plain value that SwiftData
+  (persistence) and `Codable` touch off the main actor.
+- Encodes/decodes as the **bare string** (a `singleValueContainer`), so its on-disk / on-wire form is just
+  the id — no wrapper keys.
+
+## How to use
+
+**Type a genuine entity's id** with it, and mint one from a raw string:
+
+```swift
+var id: EntityID<WordStorageEntity>              // a @Model property, a value-state field
+let id = EntityID<WordStorageEntity>(rawValue: uuidProvider.create())
+someEntity.id.rawValue                            // the underlying string, if you need it
+```
+
+**When to use — and when not.** Use `EntityID` for a **real entity identity** (a persisted record, a
+domain value with its own identity). Do **not** wrap a purely **positional `ForEach` render-key** (a
+keyboard key, a character tile, an enumerated meaning/definition index) — those stay `String`;
+phantom-typing a list position buys nothing and is ceremony.
+
+**Persistence note.** Changing a persisted `@Model` id to `EntityID` is a SwiftData **schema change** —
+it needs a versioned schema + migration plan proven by a migration test. See `Storage/Schema/StorageSchema.md`.

--- a/Worday/Modal Routing/ModalRouting.md
+++ b/Worday/Modal Routing/ModalRouting.md
@@ -1,0 +1,39 @@
+# Modal Routing
+
+Programmatic modal presentation in the ProjectPrivacy **router + host + provider** shape — the modal
+counterpart of Navigation Routing. A feature presents a modal by asking the router; a dumb `ViewModifier`
+host drives `.sheet`/`.fullScreenCover`; a provider maps the destination to its view.
+
+## Components
+
+- **`ModalDestination`** — a `Hashable`, `Identifiable` value enum of every modal (`.info`), each
+  declaring a `presentationStyle` (`ModalPresentationStyle`: `.sheet(detents:)` today, `.fullScreenCover`
+  supported by the host for later). Cases carry only values, never a view state.
+- **`ModalRouter`** (`ModalRouterType`, `@Observable`, `.container`) — holds `presented: ModalDestination?`
+  with `present`/`dismiss`.
+- **`ModalHostModifier`** — a dumb `ViewModifier` (`.modalHost(router:provider:)`) that observes the
+  router and drives `.sheet(item:)` / `.fullScreenCover(item:)` (disjoint by `presentationStyle`), routing
+  a system dismiss back through `router.dismiss()`. Applied at the app root **outermost** (after
+  `.navigationHost`) so a modal covers a pushed screen.
+- **`ModalDestinationViewProvider`** (`ModalDestinationViewProviderType`) — the only place that maps a
+  `ModalDestination` to its screen, built via injected converters/factories.
+
+## How to use
+
+**Present / dismiss** — inject `ModalRouterType`:
+
+```swift
+modalRouter.present(.info)
+modalRouter.dismiss()          // also happens automatically on a system swipe-to-dismiss
+```
+
+**Add a new modal:**
+
+1. Add a case to `ModalDestination` and give it a `presentationStyle` (`.sheet([...])` or
+   `.fullScreenCover`).
+2. Add an arm to `ModalDestinationViewProvider.destinationView(for:)`; inject its builder and register the
+   provider's dependency in `ViewDependencies`.
+3. Present it from the interaction (`modalRouter.present(.newModal)`).
+
+The host never changes. Hosts and the `AnyView` provider are view-layer (not unit-tested — see
+`RoutingTestNotes.md`); the behaviour (presenting the right destination) is asserted on a `ModalRouterMock`.

--- a/Worday/Navigation Routing/NavigationRouting.md
+++ b/Worday/Navigation Routing/NavigationRouting.md
@@ -1,0 +1,40 @@
+# Navigation Routing
+
+Programmatic, single-stack navigation in the ProjectPrivacy **router + host + provider** shape. A feature
+pushes a screen by asking the router; a dumb `ViewModifier` host owns the `NavigationStack`; a provider
+maps each destination to its view. Nothing pushes a `NavigationStack` or a `View` by hand.
+
+## Components
+
+- **`NavigationDestination`** — a `Hashable` value enum of every pushable screen (`.wordList`,
+  `.wordMeaning(word:)`). Cases carry only lightweight values, never a view model or view state.
+- **`NavigationRouter`** (`NavigationRouterType`, `@Observable`, `.container`) — holds the stack as
+  `path: [NavigationDestination]`. Feature-facing API: `push`/`pop`/`popToRoot`. `setPath` exists only so
+  the host can route SwiftUI's own pops back through the router.
+- **`NavigationHostModifier`** — a dumb `ViewModifier` (`.navigationHost(router:provider:)`) that wraps
+  content in a `NavigationStack` bound to `router.path` and resolves pushes through the provider. Applied
+  once at the app root in `WordayApp`.
+- **`NavigationDestinationViewProvider`** (`NavigationDestinationViewProviderType`) — the only place that
+  maps a `NavigationDestination` to its screen, building the view model via injected factories/converters.
+
+## How to use
+
+**Push a screen** — inject `NavigationRouterType` and push a value case:
+
+```swift
+navigationRouter.push(.wordMeaning(word: "guide"))   // or .push(.wordList)
+navigationRouter.pop()                                // or .popToRoot()
+```
+
+**Add a new pushable screen:**
+
+1. Add a case to `NavigationDestination` (lightweight values only).
+2. Add an arm to `NavigationDestinationViewProvider.destinationView(for:)` that builds the screen from its
+   injected factory/converter; inject that collaborator into the provider (and register it in
+   `ViewDependencies`).
+3. Push it from wherever the interaction lives (`router.push(.newScreen(...))`).
+
+The host never changes. The pushed screen owns its own nav chrome (title/back). The hosts and the
+`AnyView` provider are view-layer and are not unit-tested (see `WordayTests/Tests/RoutingTestNotes.md`);
+the *behaviour* — pushing the right destination — is asserted on a `NavigationRouterMock` in the view
+model/converter that pushes.

--- a/Worday/Storage/Schema/StorageSchema.md
+++ b/Worday/Storage/Schema/StorageSchema.md
@@ -1,0 +1,37 @@
+# Storage Schema & Migrations
+
+The persisted model (`WordStorageEntity`) and the versioned-schema + migration machinery that lets its
+shape change without losing shipped users' data.
+
+## Components
+
+- **`WordStorageEntity`** — the SwiftData `@Model` for one played word (`id: EntityID<WordStorageEntity>`,
+  `word`, `playedAt`). It is defined in the **latest** versioned schema and exposed to the app via
+  `typealias WordStorageEntity = WordStorageSchemaV2.WordStorageEntity`, so app code always uses the
+  current shape.
+- **`WordStorageSchemaV1`** — the original shape (`id: String`). It exists only so the migration plan can
+  read an old on-disk store; no app code uses it.
+- **`WordStorageSchemaV2`** — the current shape (`id: EntityID`).
+- **`WordStorageMigrationPlan`** — the `SchemaMigrationPlan` wired into `sharedModelContainer`. Because a
+  property *type* change (`String` → `EntityID`) is not a lightweight migration, the custom stage carries
+  data by hand: `willMigrate` reads the V1 rows into memory and empties the store (so the structural
+  change runs against an empty store); `didMigrate` re-inserts them as V2, wrapping the old id string in an
+  `EntityID`. **Every field survives, including the id value.**
+
+## How to use
+
+**Reading/writing** stored words goes through `WordStorageModelContextType` (the injected `ModelContext`
+seam) and the `PlayedWordsLibrary` projection — never touch `sharedModelContainer` directly from a feature.
+
+**Changing the model** (add/remove/retype a property):
+
+1. Add a new `WordStorageSchemaVN` with the new shape and point the `typealias` at it.
+2. Keep the previous version(s) intact.
+3. Add a `MigrationStage` to `WordStorageMigrationPlan` (lightweight for add/remove; **custom** for a type
+   change, following the drain-empty-refill pattern above so data is preserved).
+4. **Add a migration test.** A fresh-install run cannot catch a broken migration.
+   `WordStorageMigrationTests` writes a real on-disk store in the *old* schema, re-opens it with the new
+   schema + plan, and asserts every row survived. Do the same for the new stage.
+
+Never change a persisted `@Model` property in place without a version + stage + test — existing installs
+would crash at `ModelContainer` init (the `fatalError` in `sharedModelContainer`).

--- a/Worday/Storage/Storage.md
+++ b/Worday/Storage/Storage.md
@@ -1,0 +1,36 @@
+# Storage
+
+On-device persistence for the player's played-word history (SwiftData), plus the observable projection the
+display surfaces read from.
+
+## Components
+
+- **`WordStorageEntity`** — the SwiftData `@Model` for one played word (`id`, `word`, `playedAt`). Its
+  shape is versioned; see `Schema/StorageSchema.md`.
+- **`sharedModelContainer`** — the app's single `ModelContainer`, wired with `WordStorageMigrationPlan` so
+  older stores upgrade on launch.
+- **`WordStorageModelContextType`** — the injected seam over `ModelContext` (`insert`/`save`/`fetchAll`).
+  The **write path** goes through this (the game stores a word when solved).
+- **`PlayedWordsLibrary`** (`PlayedWordsLibraryType`, `@Observable`, `.container`) — the single observable
+  read-projection over the store. The store stays the source of truth; the library only derives from it
+  (`load()` at launch, `reload()` after a write). See CLAUDE.md → "Shared Store Projections".
+
+## How to use
+
+**Read** the played words from the shared projection — never call `fetchAll()` from a feature:
+
+```swift
+playedWordsLibrary.words        // [WordStorageEntity], observable
+```
+
+Readers inject `PlayedWordsLibraryType` (e.g. `StreakUseCase`, `WordListViewStateConverter`).
+
+**Write** a word (the game's write-owner, `WordProviderUseCase`):
+
+```swift
+wordContext.insert(.init(id: .init(rawValue: uuidProvider.create()), word: word, playedAt: dateProvider.now()))
+try? wordContext.save()
+playedWordsLibrary.reload()     // refresh the projection so every reader re-renders
+```
+
+The library is hydrated once at launch in `WordayApp.init` via `load()`.


### PR DESCRIPTION
**Phase D (final)** of the ProjectPrivacy architecture migration. **Documentation only** — no behaviour change; **72 tests green**.

## What
- A `<Feature>.md` "how to use" doc for each folder the migration created, per the Feature Documentation rule:
  - `Navigation Routing/NavigationRouting.md`, `Modal Routing/ModalRouting.md`
  - `Common/Entity ID/EntityID.md`
  - `Storage/Storage.md` (+ `Storage/Schema/StorageSchema.md` for the versioned-schema / migration machinery)
- An **Architecture** + **Building & testing** section in the root README.

## Deliberately not done: per-feature DI re-split
Applying the CLAUDE.md's own "don't add ceremony" bar: the **per-area** DI grouping from WRD-41 (`CommonDependencies`, `APIClientDependencies`, `DictionaryDependencies`, `WordDependencies`, `ViewDependencies` + a thin aggregator) is right-sized for a single-screen app. ProjectPrivacy's per-*feature* split earns its keep across its dozens of features; splitting Worday further would be ceremony. Trivial to revisit if the app grows — say the word and I'll do it.

## Migration complete
This closes the A→D sequence (WRD-43 routing → WRD-44 store projection → WRD-45 EntityID → WRD-46 docs). The alert host (E) stays deferred until a real alert appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)