### PR TITLE
[WRD-47] Alert host (Phase E) + first consumers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,9 +467,14 @@ parts per concern, and a **lightweight value destination** enum:
 - **Behaviour is asserted where it originates** — the view model/converter that pushes/presents
   (`push(.wordList)`, `present(.info)`), against a `…RouterMock`.
 
-This is the general **presentation-host** rule: any app-wide decoration (navigation, modals, and future
-alerts) is a `ViewModifier` host + provider driven by a `.container` `@Observable` router — never an
-inline container or a nested host `View`. See `ProjectPrivacyMigration-Design.md`.
+This is the general **presentation-host** rule: any app-wide decoration (navigation, modals, alerts) is a
+`ViewModifier` host driven by a `.container` `@Observable` router — never an inline container or a nested
+host `View`. Hosts are applied at the app root and **order is layering**: `.navigationHost` (innermost) →
+`.modalHost` → `.alertHost` (outermost), so a modal covers a pushed screen and an alert covers everything.
+A navigation/modal host also takes a `…ViewProvider` (the destination→screen map); the **alert** host
+needs none — an `AlertState` is a plain value, and feature-specific alert content is built by small
+factories kept next to the feature (e.g. `AlertState.meaningLoadFailure(onRetry:)` in `Domain/Dictionary`).
+See `Alert Routing/AlertRouting.md` and `ProjectPrivacyMigration-Design.md`.
 
 ---
 

--- a/Worday/Alert Routing/AlertHostModifier.swift
+++ b/Worday/Alert Routing/AlertHostModifier.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// Adds alert presentation to whatever view it modifies. It observes the `AlertRouterType` and drives
+/// `.alert(…)`. Like the other hosts it is dumb: it renders the router's `AlertState` and forwards each
+/// button as a `UserAction`, owning no business logic.
+///
+/// `.alert` has no `item:` overload, so presentation is bound to an `isPresented` bool derived from
+/// `presented`. SwiftUI auto-dismisses on any button tap, flipping that bool to `false`, which routes
+/// back through `dismiss()` — so the button closures stay pure (just the user's action, not the dismiss).
+///
+/// Apply it once at the app root via `.alertHost(router:)`, **after** `.modalHost(…)`, so alerts sit
+/// above modals and pushed screens.
+struct AlertHostModifier: ViewModifier {
+
+    // MARK: - Life Cycle
+
+    init(router: AlertRouterType) {
+        self.router = router
+    }
+
+    // MARK: - Publics
+
+    func body(content: Content) -> some View {
+        // Reading `presented` here registers SwiftUI observation on the router.
+        let alert = router.presented
+        content.alert(
+            alert?.title ?? "",
+            isPresented: Binding(
+                get: { alert != nil },
+                set: { if !$0 { router.dismiss() } }
+            ),
+            presenting: alert,
+            actions: { alert in
+                ForEach(Array(alert.buttons.enumerated()), id: \.offset) { _, button in
+                    Button(button.title, role: buttonRole(for: button.role)) {
+                        button.onTap.action()
+                    }
+                }
+            },
+            message: { alert in
+                if let message = alert.message {
+                    Text(message)
+                }
+            }
+        )
+    }
+
+    // MARK: - Privates
+
+    private let router: AlertRouterType
+
+    private func buttonRole(for role: AlertState.Button.Role) -> ButtonRole? {
+        switch role {
+        case .standard: nil
+        case .cancel: .cancel
+        case .destructive: .destructive
+        }
+    }
+}
+
+extension View {
+    /// Hosts programmatic alerts for this view, driven by the shared `AlertRouterType`.
+    func alertHost(router: AlertRouterType) -> some View {
+        modifier(AlertHostModifier(router: router))
+    }
+}

--- a/Worday/Alert Routing/AlertRouter.swift
+++ b/Worday/Alert Routing/AlertRouter.swift
@@ -1,0 +1,30 @@
+import Observation
+
+/// Coordinates the single alert the root `.alertHost(…)` is presenting. A shared instance is held by the
+/// DI container (`.container` scope), so any feature can have it injected and surface an error or
+/// confirmation from anywhere — `present(_:)` / `dismiss()` — without knowing about the view hierarchy
+/// and without a global singleton.
+///
+/// Alerts are strictly one-at-a-time: presenting while one is showing replaces its state.
+@MainActor
+protocol AlertRouterType: AnyObject {
+    var presented: AlertState? { get }
+    func present(_ alert: AlertState)
+    func dismiss()
+}
+
+@Observable
+final class AlertRouter: AlertRouterType {
+
+    // MARK: - Publics
+
+    private(set) var presented: AlertState?
+
+    func present(_ alert: AlertState) {
+        presented = alert
+    }
+
+    func dismiss() {
+        presented = nil
+    }
+}

--- a/Worday/Alert Routing/AlertRouting.md
+++ b/Worday/Alert Routing/AlertRouting.md
@@ -1,0 +1,40 @@
+# Alert Routing
+
+Programmatic alerts in the same **router + host** shape as Navigation and Modal Routing (no provider —
+the alert content is a plain value). A feature surfaces an alert by asking the router; a dumb
+`ViewModifier` host drives SwiftUI's `.alert`.
+
+## Components
+
+- **`AlertState`** — a value description of an alert: `title`, optional `message`, and `buttons` (each a
+  `title`, a `Role` — `.standard` / `.cancel` / `.destructive` — and an `onTap: UserAction`). `Equatable`.
+- **`AlertRouter`** (`AlertRouterType`, `@Observable`, `.container`) — holds `presented: AlertState?` with
+  `present`/`dismiss`. One alert at a time; presenting replaces.
+- **`AlertHostModifier`** — a dumb `ViewModifier` (`.alertHost(router:)`) that renders the router's
+  `AlertState` into `.alert`, maps each `Role` to a SwiftUI `ButtonRole`, and routes SwiftUI's auto-dismiss
+  (any button tap) back through `dismiss()` — so button closures stay pure (just the action). Applied at
+  the app root **outermost**, after `.modalHost`, so alerts sit above modals and pushed screens.
+
+Feature-specific alert content is built with small factories kept next to the feature, not on `AlertState`
+— e.g. `AlertState.meaningLoadFailure(onRetry:)` in `Domain/Dictionary`.
+
+## How to use
+
+Inject `AlertRouterType` and present a value:
+
+```swift
+alertRouter.present(.meaningLoadFailure(onRetry: { [weak self] in self?.retry() }))
+alertRouter.present(.init(title: "Something went wrong",
+                          message: "Please delete and re-install the app.",
+                          buttons: [.init(title: "OK", role: .cancel, onTap: .empty)]))
+```
+
+Dismissal is automatic on any button tap (routed through `dismiss()`), so a button's `onTap` performs only
+its action; a plain "OK" is `.empty`.
+
+**Current consumers:** the word-meaning screen and the finished-game meaning section present a Retry alert
+when the dictionary lookup fails (`WordMeaningViewModel` / `FinishedGameViewModel`); the game presents a
+fatal-error alert when the day's word can't be resolved (`GameViewModel`).
+
+The host is view-layer and not unit-tested (see `WordayTests/Tests/AlertRoutingTestNotes.md`); the
+behaviour — presenting the right alert, and Retry re-loading — is asserted on an `AlertRouterMock`.

--- a/Worday/Alert Routing/AlertState.swift
+++ b/Worday/Alert Routing/AlertState.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A value description of the alert the `.alertHost(…)` should show — title, optional message, and one or
+/// more buttons. `Equatable` (its button closures are `UserAction`s), so it is snapshot-testable and can
+/// be asserted on an `AlertRouterMock`.
+struct AlertState: Equatable {
+    let title: String
+    let message: String?
+    let buttons: [Button]
+
+    init(title: String, message: String? = nil, buttons: [Button]) {
+        self.title = title
+        self.message = message
+        self.buttons = buttons
+    }
+}
+
+extension AlertState {
+    struct Button: Equatable {
+        let title: String
+        let role: Role
+        let onTap: UserAction
+
+        init(title: String, role: Role = .standard, onTap: UserAction) {
+            self.title = title
+            self.role = role
+            self.onTap = onTap
+        }
+
+        /// The presentation role of a button — mapped to SwiftUI's `ButtonRole` by the host, so the state
+        /// stays free of SwiftUI.
+        enum Role: Equatable {
+            case standard
+            case cancel
+            case destructive
+        }
+    }
+}

--- a/Worday/Application/WordayApp.swift
+++ b/Worday/Application/WordayApp.swift
@@ -14,6 +14,7 @@ struct WordayApp: App {
         self.navigationDestinationViewProvider = container.resolve()
         self.modalRouter = container.resolve()
         self.modalDestinationViewProvider = container.resolve()
+        self.alertRouter = container.resolve()
 
         // Hydrate the shared played-words projection once at launch; writers reload() it thereafter.
         let playedWordsLibrary: PlayedWordsLibraryType = container.resolve()
@@ -31,6 +32,7 @@ struct WordayApp: App {
             GameView(viewModel: gameViewModelFactory.make())
                 .navigationHost(router: navigationRouter, provider: navigationDestinationViewProvider)
                 .modalHost(router: modalRouter, provider: modalDestinationViewProvider)
+                .alertHost(router: alertRouter)
         }
     }
 
@@ -44,4 +46,5 @@ struct WordayApp: App {
     private let navigationDestinationViewProvider: NavigationDestinationViewProviderType
     private let modalRouter: ModalRouterType
     private let modalDestinationViewProvider: ModalDestinationViewProviderType
+    private let alertRouter: AlertRouterType
 }

--- a/Worday/Common/Dependency Injection/CommonDependencies.swift
+++ b/Worday/Common/Dependency Injection/CommonDependencies.swift
@@ -33,6 +33,8 @@ extension ContainerType {
 
         register(in: .container) { _ in ModalRouter() as ModalRouterType }
 
+        register(in: .container) { _ in AlertRouter() as AlertRouterType }
+
         register(in: .container) { _ in FinishGameRelay() as FinishGameRelayType }
 
         register(in: .container) { container in

--- a/Worday/Domain/Dictionary/MeaningLoadFailureAlert.swift
+++ b/Worday/Domain/Dictionary/MeaningLoadFailureAlert.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// The alert shown when a word's dictionary meaning fails to load — shared by both meaning surfaces
+/// (the pushed word-meaning screen and the finished-game meaning section) so they present the same thing.
+/// Kept here (the dictionary domain) rather than on the generic `AlertState` infra.
+extension AlertState {
+    static func meaningLoadFailure(onRetry: @escaping () -> Void) -> AlertState {
+        AlertState(
+            title: "Couldn’t load the meaning",
+            message: "Check your connection and try again.",
+            buttons: [
+                .init(title: "Retry", onTap: .init(onRetry)),
+                .init(title: "OK", role: .cancel, onTap: .empty)
+            ]
+        )
+    }
+}

--- a/Worday/Views/Finished/FinishedGameViewModel.swift
+++ b/Worday/Views/Finished/FinishedGameViewModel.swift
@@ -10,13 +10,15 @@ struct FinishedGameViewModelFactory: FinishedGameViewModelFactoryType {
     let streakUseCase: StreakUseCaseType
     let attemptTrackerUseCase: AttemptTrackerUseCaseType
     let navigationRouter: NavigationRouterType
+    let alertRouter: AlertRouterType
 
     func make(for word: String) -> FinishedGameViewModelType {
         FinishedGameViewModel(word: word,
                               dictionaryUseCase: dictionaryUseCase,
                               streakUseCase: streakUseCase,
                               attemptTrackerUseCase: attemptTrackerUseCase,
-                              navigationRouter: navigationRouter)
+                              navigationRouter: navigationRouter,
+                              alertRouter: alertRouter)
     }
 }
 
@@ -35,11 +37,13 @@ final class FinishedGameViewModel: FinishedGameViewModelType {
         dictionaryUseCase: DictionaryUseCaseType,
         streakUseCase: StreakUseCaseType,
         attemptTrackerUseCase: AttemptTrackerUseCaseType,
-        navigationRouter: NavigationRouterType
+        navigationRouter: NavigationRouterType,
+        alertRouter: AlertRouterType
     ) {
         self.word = word
         self.dictionaryUseCase = dictionaryUseCase
         self.navigationRouter = navigationRouter
+        self.alertRouter = alertRouter
         self.title = attemptTrackerUseCase.feedbackMessage()
         self.scoreMessage = "You solved it on your \(attemptTrackerUseCase.ordinalString()) try"
         self.currentStreakValue = streakUseCase.calculateStreak()
@@ -64,6 +68,7 @@ final class FinishedGameViewModel: FinishedGameViewModelType {
     func load() async {
         dataState = await dictionaryUseCase.meaning(for: word)
         selectDefaultMeaningIfNeeded()
+        if case .error = dataState { presentRetryAlert() }
     }
 
     // MARK: - Privates
@@ -71,6 +76,7 @@ final class FinishedGameViewModel: FinishedGameViewModelType {
     @ObservationIgnored private let word: String
     @ObservationIgnored private let dictionaryUseCase: DictionaryUseCaseType
     @ObservationIgnored private let navigationRouter: NavigationRouterType
+    @ObservationIgnored private let alertRouter: AlertRouterType
 
     @ObservationIgnored private let title: String
     @ObservationIgnored private let scoreMessage: String
@@ -111,6 +117,14 @@ final class FinishedGameViewModel: FinishedGameViewModelType {
     private func selectDefaultMeaningIfNeeded() {
         guard selectedMeaning == nil, case let .data(model) = dataState else { return }
         selectedMeaning = meanings(from: model).first
+    }
+
+    private func presentRetryAlert() {
+        alertRouter.present(.meaningLoadFailure(onRetry: { [weak self] in self?.retry() }))
+    }
+
+    private func retry() {
+        Task { await load() }
     }
 
     private var allWordsButtonState: FinishedGameViewState.AllWordButton {

--- a/Worday/Views/GameViewModel.swift
+++ b/Worday/Views/GameViewModel.swift
@@ -10,12 +10,14 @@ struct GameViewModelFactory: GameViewModelFactoryType {
     let ongoingGameViewModelFactory: OngoingGameViewModelFactoryType
     let finishedGameViewModelFactory: FinishedGameViewModelFactoryType
     let finishGameRelay: FinishGameRelayType
+    let alertRouter: AlertRouterType
 
     func make() -> GameViewModelType {
         GameViewModel(wordProviderUseCase: fetchWordUseCase,
                       ongoingGameViewModelFactory: ongoingGameViewModelFactory,
                       finishedGameViewModelFactory: finishedGameViewModelFactory,
-                      finishGameRelay: finishGameRelay)
+                      finishGameRelay: finishGameRelay,
+                      alertRouter: alertRouter)
     }
 }
 
@@ -38,11 +40,13 @@ final class GameViewModel: GameViewModelType {
     init(wordProviderUseCase: WordProviderUseCaseType,
          ongoingGameViewModelFactory: OngoingGameViewModelFactoryType,
          finishedGameViewModelFactory: FinishedGameViewModelFactoryType,
-         finishGameRelay: FinishGameRelayType) {
+         finishGameRelay: FinishGameRelayType,
+         alertRouter: AlertRouterType) {
         self.wordProviderUseCase = wordProviderUseCase
         self.ongoingGameViewModelFactory = ongoingGameViewModelFactory
         self.finishedGameViewModelFactory = finishedGameViewModelFactory
         self.finishGameRelay = finishGameRelay
+        self.alertRouter = alertRouter
     }
 
     // MARK: - Publics
@@ -57,6 +61,7 @@ final class GameViewModel: GameViewModelType {
         switch result {
         case .error:
             viewState = .error
+            presentFatalErrorAlert()
         case let .word(word):
             viewState = .game(viewModel: ongoingGameViewModelFactory.make(with: word))
         case let .noWordToday(lastPlayedWord):
@@ -78,6 +83,15 @@ final class GameViewModel: GameViewModelType {
     @ObservationIgnored private let ongoingGameViewModelFactory: OngoingGameViewModelFactoryType
     @ObservationIgnored private let finishedGameViewModelFactory: FinishedGameViewModelFactoryType
     @ObservationIgnored private let finishGameRelay: FinishGameRelayType
+    @ObservationIgnored private let alertRouter: AlertRouterType
 
     @ObservationIgnored private var latestFetchResult: FetchWordModel?
+
+    private func presentFatalErrorAlert() {
+        alertRouter.present(.init(
+            title: "Something went wrong",
+            message: "Please delete and re-install the app.",
+            buttons: [.init(title: "OK", role: .cancel, onTap: .empty)]
+        ))
+    }
 }

--- a/Worday/Views/ViewDependencies.swift
+++ b/Worday/Views/ViewDependencies.swift
@@ -8,7 +8,8 @@ extension ContainerType {
             GameViewModelFactory(fetchWordUseCase: container.resolve(),
                                  ongoingGameViewModelFactory: container.resolve(),
                                  finishedGameViewModelFactory: container.resolve(),
-                                 finishGameRelay: container.resolve())
+                                 finishGameRelay: container.resolve(),
+                                 alertRouter: container.resolve())
             as GameViewModelFactoryType
         }
 
@@ -24,12 +25,14 @@ extension ContainerType {
             FinishedGameViewModelFactory(dictionaryUseCase: container.resolve(),
                                          streakUseCase: container.resolve(),
                                          attemptTrackerUseCase: container.resolve(),
-                                         navigationRouter: container.resolve())
+                                         navigationRouter: container.resolve(),
+                                         alertRouter: container.resolve())
             as FinishedGameViewModelFactoryType
         }
 
         register { container in
-            WordMeaningViewModelFactory(dictionaryUseCase: container.resolve())
+            WordMeaningViewModelFactory(dictionaryUseCase: container.resolve(),
+                                        alertRouter: container.resolve())
             as WordMeaningViewModelFactoryType
         }
 

--- a/Worday/Views/Word Meaning/WordMeaningViewModel.swift
+++ b/Worday/Views/Word Meaning/WordMeaningViewModel.swift
@@ -7,9 +7,10 @@ protocol WordMeaningViewModelFactoryType {
 
 struct WordMeaningViewModelFactory: WordMeaningViewModelFactoryType {
     let dictionaryUseCase: DictionaryUseCaseType
+    let alertRouter: AlertRouterType
 
     func make(word: String) -> WordMeaningViewModelType {
-        WordMeaningViewModel(word: word, dictionaryUseCase: dictionaryUseCase)
+        WordMeaningViewModel(word: word, dictionaryUseCase: dictionaryUseCase, alertRouter: alertRouter)
     }
 }
 
@@ -23,9 +24,10 @@ final class WordMeaningViewModel: WordMeaningViewModelType {
 
     // MARK: - Life Cycle
 
-    init(word: String, dictionaryUseCase: DictionaryUseCaseType) {
+    init(word: String, dictionaryUseCase: DictionaryUseCaseType, alertRouter: AlertRouterType) {
         self.word = word
         self.dictionaryUseCase = dictionaryUseCase
+        self.alertRouter = alertRouter
     }
 
     // MARK: - Publics
@@ -44,12 +46,14 @@ final class WordMeaningViewModel: WordMeaningViewModelType {
     func load() async {
         dataState = await dictionaryUseCase.meaning(for: word)
         selectDefaultMeaningIfNeeded()
+        if case .error = dataState { presentRetryAlert() }
     }
 
     // MARK: - Privates
 
     @ObservationIgnored private let word: String
     @ObservationIgnored private let dictionaryUseCase: DictionaryUseCaseType
+    @ObservationIgnored private let alertRouter: AlertRouterType
 
     private var dataState: DictionaryDataState = .loading
     private var selectedMeaning: WordMeaningViewState.MeaningViewState.Meaning?
@@ -72,6 +76,14 @@ final class WordMeaningViewModel: WordMeaningViewModelType {
     private func selectDefaultMeaningIfNeeded() {
         guard selectedMeaning == nil, case let .data(model) = dataState else { return }
         selectedMeaning = meanings(from: model).first
+    }
+
+    private func presentRetryAlert() {
+        alertRouter.present(.meaningLoadFailure(onRetry: { [weak self] in self?.retry() }))
+    }
+
+    private func retry() {
+        Task { await load() }
     }
 }
 

--- a/WordayTests/Mocks/AlertRouterMock.swift
+++ b/WordayTests/Mocks/AlertRouterMock.swift
@@ -1,0 +1,23 @@
+@testable import Worday
+
+final class AlertRouterMock: AlertRouterType {
+
+    enum Call: Equatable {
+        case present(alert: AlertState)
+        case dismiss
+    }
+
+    private(set) var presented: AlertState?
+
+    func present(_ alert: AlertState) {
+        presented = alert
+        calls.append(.present(alert: alert))
+    }
+
+    func dismiss() {
+        presented = nil
+        calls.append(.dismiss)
+    }
+
+    private(set) var calls: [Call] = []
+}

--- a/WordayTests/Tests/AlertRouterTests.swift
+++ b/WordayTests/Tests/AlertRouterTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import Worday
+
+struct AlertRouterTests {
+    let sut = AlertRouter()
+
+    @Test("it starts with nothing presented")
+    func startsEmpty() {
+        #expect(sut.presented == nil)
+    }
+
+    @Test("present sets the alert")
+    func presentSetsAlert() {
+        // `.fake` actions so the AlertState compares equal to itself (UserAction equality quirk).
+        let alert = AlertState(title: "Oops", buttons: [.init(title: "OK", role: .cancel, onTap: .fake)])
+
+        sut.present(alert)
+
+        #expect(sut.presented == alert)
+    }
+
+    @Test("dismiss clears the alert")
+    func dismissClears() {
+        sut.present(AlertState(title: "Oops", buttons: [.init(title: "OK", onTap: .fake)]))
+
+        sut.dismiss()
+
+        #expect(sut.presented == nil)
+    }
+}

--- a/WordayTests/Tests/AlertRoutingTestNotes.md
+++ b/WordayTests/Tests/AlertRoutingTestNotes.md
@@ -1,0 +1,13 @@
+# Alert Routing — Test Notes
+
+`AlertRouter` is covered by `AlertRouterTests`, and its registration by `DependencyGraphTests`.
+
+**`AlertHostModifier` is intentionally not unit-tested** — like the navigation/modal hosts it is a dumb
+`ViewModifier` that renders the router's `AlertState` into SwiftUI's `.alert` and forwards each button as
+a `UserAction`. There is nothing to assert that isn't SwiftUI's own behaviour.
+
+The *behaviour* that matters — presenting the right alert — is asserted where it originates, against an
+`AlertRouterMock`: `WordMeaningViewModelTests` / `FinishedGameViewModelTests` (the meaning-load retry
+alert, and that Retry re-loads) and `GameViewModelTests` (the fatal-error alert). Because `AlertState`
+carries `UserAction` closures, those tests assert on inspectable fields (title, button titles) and invoke
+the buttons — rather than comparing whole `AlertState` values (`UserAction` equality is flag-based).

--- a/WordayTests/Tests/DependencyGraphTests.swift
+++ b/WordayTests/Tests/DependencyGraphTests.swift
@@ -44,6 +44,7 @@ struct DependencyGraphTests {
         _ = container.resolve() as NavigationDestinationViewProviderType
         _ = container.resolve() as ModalDestinationViewProviderType
         _ = container.resolve() as PlayedWordsLibraryType
+        _ = container.resolve() as AlertRouterType
     }
 
     @Test("a .container-scoped dependency resolves to the same instance")

--- a/WordayTests/Tests/View Models/FinishedGameViewModelTests.swift
+++ b/WordayTests/Tests/View Models/FinishedGameViewModelTests.swift
@@ -9,12 +9,14 @@ struct FinishedGameViewModelTests {
     let mockStreakUseCase: StreakUseCaseMock
     let mockAttemptTrackerUseCase: AttemptTrackerUseCaseMock
     let mockNavigationRouter: NavigationRouterMock
+    let mockAlertRouter: AlertRouterMock
 
     init() {
         mockDictionaryUseCase = .init()
         mockStreakUseCase = .init()
         mockAttemptTrackerUseCase = .init()
         mockNavigationRouter = .init()
+        mockAlertRouter = .init()
 
         mockAttemptTrackerUseCase.ordinalStringReturnValue = "1st"
         mockAttemptTrackerUseCase.feedbackMessageReturnValue = "Great job! 🎉"
@@ -25,7 +27,17 @@ struct FinishedGameViewModelTests {
                     dictionaryUseCase: mockDictionaryUseCase,
                     streakUseCase: mockStreakUseCase,
                     attemptTrackerUseCase: mockAttemptTrackerUseCase,
-                    navigationRouter: mockNavigationRouter)
+                    navigationRouter: mockNavigationRouter,
+                    alertRouter: mockAlertRouter)
+    }
+
+    @Test("it presents a retry alert when the meaning fails to load")
+    func presentsRetryAlertOnError() async {
+        mockDictionaryUseCase.meaningReturnValue = .error
+
+        await sut.load()
+
+        #expect(mockAlertRouter.presented?.buttons.map(\.title) == ["Retry", "OK"])
     }
 
     @Test("it shows the loading state before the meaning is loaded")

--- a/WordayTests/Tests/View Models/GameViewModelTests.swift
+++ b/WordayTests/Tests/View Models/GameViewModelTests.swift
@@ -8,18 +8,21 @@ struct GameViewModelTests {
     let mockOngoingGameViewModelFactory: OngoingGameViewModelFactoryMock
     let mockFinishedGameViewModelFactory: FinishedGameViewModelFactoryMock
     let mockFinishGameRelay: FinishGameRelayMock
+    let mockAlertRouter: AlertRouterMock
 
     init() {
         mockWordProviderUseCase = .init()
         mockOngoingGameViewModelFactory = .init()
         mockFinishedGameViewModelFactory = .init()
         mockFinishGameRelay = .init()
+        mockAlertRouter = .init()
 
         sut = .init(
             wordProviderUseCase: mockWordProviderUseCase,
             ongoingGameViewModelFactory: mockOngoingGameViewModelFactory,
             finishedGameViewModelFactory: mockFinishedGameViewModelFactory,
-            finishGameRelay: mockFinishGameRelay
+            finishGameRelay: mockFinishGameRelay,
+            alertRouter: mockAlertRouter
         )
     }
 
@@ -48,6 +51,7 @@ struct GameViewModelTests {
         #expect(mockOngoingGameViewModelFactory.calls.isEmpty)
         #expect(mockFinishedGameViewModelFactory.calls.isEmpty)
         #expect(sut.viewState == .error)
+        #expect(mockAlertRouter.presented?.title == "Something went wrong")
     }
 
     @Test("refresh dedupes an unchanged fetch result")

--- a/WordayTests/Tests/View Models/WordMeaningViewModelTests.swift
+++ b/WordayTests/Tests/View Models/WordMeaningViewModelTests.swift
@@ -5,10 +5,42 @@ import Foundation
 struct WordMeaningViewModelTests {
     let sut: WordMeaningViewModel
     let mockDictionaryUseCase: DictionaryUseCaseMock
+    let mockAlertRouter: AlertRouterMock
 
     init() {
         mockDictionaryUseCase = .init()
-        sut = .init(word: "abcde", dictionaryUseCase: mockDictionaryUseCase)
+        mockAlertRouter = .init()
+        sut = .init(word: "abcde", dictionaryUseCase: mockDictionaryUseCase, alertRouter: mockAlertRouter)
+    }
+
+    @Test("it presents a retry alert when the meaning fails to load")
+    func presentsRetryAlertOnError() async {
+        mockDictionaryUseCase.meaningReturnValue = .error
+
+        await sut.load()
+
+        #expect(mockAlertRouter.presented?.buttons.map(\.title) == ["Retry", "OK"])
+    }
+
+    @Test("the retry button re-loads the meaning")
+    func retryReloadsTheMeaning() async {
+        mockDictionaryUseCase.meaningReturnValue = .error
+        await sut.load()
+        #expect(mockDictionaryUseCase.calls == [.meaning(word: "abcde")])
+
+        mockAlertRouter.presented?.buttons.first?.onTap.action()   // Retry
+        for _ in 0..<100 where mockDictionaryUseCase.calls.count < 2 { await Task.yield() }
+
+        #expect(mockDictionaryUseCase.calls == [.meaning(word: "abcde"), .meaning(word: "abcde")])
+    }
+
+    @Test("it does not present an alert on success")
+    func noAlertOnSuccess() async {
+        mockDictionaryUseCase.meaningReturnValue = .data(.fake())
+
+        await sut.load()
+
+        #expect(mockAlertRouter.calls == [])
     }
 
     @Test("it shows the loading state before the meaning is loaded")


### PR DESCRIPTION
Adopts ProjectPrivacy's **alert-routing** shape — the deferred **Phase E** of the architecture migration — now that there's a genuine use. **79 tests green**; app verified in the simulator.

## Infrastructure (`Alert Routing/`)
- **`AlertState`** — a value description of an alert (title, optional message, buttons with a `Role` + `UserAction`).
- **`AlertRouter`** (`AlertRouterType`, `@Observable`, `.container`) — `present`/`dismiss`, one at a time.
- **`AlertHostModifier`** (`.alertHost(router:)`) — a dumb `ViewModifier` over SwiftUI's `.alert`, applied at the app root **outermost** (after `.modalHost`); a system dismiss routes back through `dismiss()`. No provider — an alert is a plain value.

Layering is now `navigationHost → modalHost → alertHost` (alerts cover everything).

## Consumers (all three, as requested)
- **Meaning-load failure → Retry / OK alert** on both the pushed word-meaning screen (`WordMeaningViewModel`) and the finished-game meaning section (`FinishedGameViewModel`) — turns today's dead-end inline error into a recoverable one. Shared `AlertState.meaningLoadFailure(onRetry:)` factory in `Domain/Dictionary`.
- **Fatal error → alert** in `GameViewModel` when the day's word can't be resolved.

## Tests
`AlertRouterTests` + `AlertRouterMock`; the three view-model suites assert the right alert is presented (and that **Retry re-loads**) against the mock; `DependencyGraphTests` covers the registration. Host is view-layer (`AlertRoutingTestNotes.md`). Docs: `Alert Routing/AlertRouting.md`; CLAUDE.md presentation-host rule updated.

This closes the last open item from the ProjectPrivacy architecture migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)