### PR TITLE
[WRD-49] Storage review fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,7 +517,11 @@ Two persistence surfaces, each behind an injected seam:
   `CaseIterable enum Key` so `reset()` clears them all.
 - **Played-word history** is **SwiftData**: the `@Model WordStorageEntity` (id, word, playedAt) via
   `WordStorageModelContextType` (`ModelContext` conforms). Access stays `@MainActor` (see
-  [Concurrency](#concurrency-swift-6)). The default `fetchAll()` sorts by `playedAt` descending.
+  [Concurrency](#concurrency-swift-6)). The default `fetchAll()` sorts by `playedAt` descending. The seam
+  is registered **`.container`** (class-bound protocol, `===` in `DependencyGraphTests`) so the writer and
+  every reader share **one** `ModelContext` over `sharedModelContainer` — an insert is immediately visible
+  to a fetch, with a single stable identity; don't register it `.default` (that hands out a fresh context
+  per resolve).
 
 Any codec (`JSONEncoder`/`JSONDecoder`) is injected via `EncoderType`/`DecoderType` — never constructed
 inline. Behaviour driven by a setting reads it **live** at the point of use, so a change takes effect
@@ -532,9 +536,10 @@ When **multiple surfaces read the same persisted collection**, don't let each ca
 the observable window everyone reads.
 
 - **`PlayedWordsLibrary`** (`PlayedWordsLibraryType`, `@Observable`, `.container`) is the projection over
-  `WordStorageModelContextType`: it owns `words`, derived via `load()` at launch (hydrated in
-  `WordayApp.init`) and `reload()` after a change. The **store stays the single source of truth** — the
-  projection only ever derives from it, so the readers can't disagree.
+  `WordStorageModelContextType`: it owns `words`, derived via a single `reload()` (called once at launch
+  to hydrate in `WordayApp.init`, and again after each change). A failed fetch keeps the last-known-good
+  `words` rather than blanking them. The **store stays the single source of truth** — the projection only
+  ever derives from it, so the readers can't disagree.
 - **Readers take the projection, not the store.** `WordListViewStateConverter` and `StreakUseCase` read
   `playedWordsLibrary.words` — never `wordContext.fetchAll()`. Because it's a shared `@Observable`, a
   change re-renders every reader natively.

--- a/Worday/Application/WordayApp.swift
+++ b/Worday/Application/WordayApp.swift
@@ -18,7 +18,7 @@ struct WordayApp: App {
 
         // Hydrate the shared played-words projection once at launch; writers reload() it thereafter.
         let playedWordsLibrary: PlayedWordsLibraryType = container.resolve()
-        playedWordsLibrary.load()
+        playedWordsLibrary.reload()
     }
 
     init() {

--- a/Worday/Storage/PlayedWordsLibrary.swift
+++ b/Worday/Storage/PlayedWordsLibrary.swift
@@ -9,7 +9,6 @@ import Observation
 @MainActor
 protocol PlayedWordsLibraryType: AnyObject {
     var words: [WordStorageEntity] { get }
-    func load()
     func reload()
 }
 
@@ -26,12 +25,12 @@ final class PlayedWordsLibrary: PlayedWordsLibraryType {
 
     private(set) var words: [WordStorageEntity] = []
 
-    func load() {
-        reload()
-    }
-
+    /// Re-derive the projection from the store. Used both to hydrate at launch and to refresh after a
+    /// write. On a fetch failure the last-known-good `words` are kept rather than blanked — the data is
+    /// safe on disk, so a transient read error must not empty the history the UI is showing.
     func reload() {
-        words = (try? wordContext.fetchAll()) ?? []
+        guard let fetched = try? wordContext.fetchAll() else { return }
+        words = fetched
     }
 
     // MARK: - Privates

--- a/Worday/Storage/Schema/WordStorageMigrationPlan.swift
+++ b/Worday/Storage/Schema/WordStorageMigrationPlan.swift
@@ -27,7 +27,9 @@ enum WordStorageMigrationPlan: SchemaMigrationPlan {
     }
 
     // The rows read in `willMigrate` and re-inserted in `didMigrate`. Migration is sequential (one stage,
-    // will-then-did) during container init, so there is no concurrent access.
+    // will-then-did) during container init, so there is no concurrent access. Both callbacks must run in
+    // the same migration pass: `willMigrate` empties and *saves* the store, so a process kill between the
+    // two would leave the store empty (the drain-empty-refill tradeoff for a non-mappable type change).
     private nonisolated(unsafe) static var carried: [Carried] = []
 
     private static let migrateV1toV2 = MigrationStage.custom(

--- a/Worday/Storage/SharedModelContainer.swift
+++ b/Worday/Storage/SharedModelContainer.swift
@@ -9,6 +9,6 @@ let sharedModelContainer: ModelContainer = {
         )
         return container
     } catch {
-        fatalError("Failed to create container")
+        fatalError("Failed to create ModelContainer: \(error)")
     }
 }()

--- a/Worday/Storage/Storage.md
+++ b/Worday/Storage/Storage.md
@@ -9,11 +9,13 @@ display surfaces read from.
   shape is versioned; see `Schema/StorageSchema.md`.
 - **`sharedModelContainer`** — the app's single `ModelContainer`, wired with `WordStorageMigrationPlan` so
   older stores upgrade on launch.
-- **`WordStorageModelContextType`** — the injected seam over `ModelContext` (`insert`/`save`/`fetchAll`).
+- **`WordStorageModelContextType`** — the injected seam over `ModelContext` (`insert`/`save`/`fetchAll`),
+  registered `.container` so the writer and every reader share one context over `sharedModelContainer`.
   The **write path** goes through this (the game stores a word when solved).
 - **`PlayedWordsLibrary`** (`PlayedWordsLibraryType`, `@Observable`, `.container`) — the single observable
   read-projection over the store. The store stays the source of truth; the library only derives from it
-  (`load()` at launch, `reload()` after a write). See CLAUDE.md → "Shared Store Projections".
+  via `reload()` (called once at launch to hydrate, and again after each write). A failed fetch keeps the
+  last-known-good words rather than blanking them. See CLAUDE.md → "Shared Store Projections".
 
 ## How to use
 
@@ -33,4 +35,4 @@ try? wordContext.save()
 playedWordsLibrary.reload()     // refresh the projection so every reader re-renders
 ```
 
-The library is hydrated once at launch in `WordayApp.init` via `load()`.
+The library is hydrated once at launch in `WordayApp.init` via `reload()`.

--- a/Worday/Storage/StorageDependencies.swift
+++ b/Worday/Storage/StorageDependencies.swift
@@ -4,7 +4,10 @@ import SwiftData
 extension ContainerType {
     /// The SwiftData persistence seam and the shared `@Observable` read-projection over it.
     func registerStorageDependencies() {
-        register { _ in ModelContext(sharedModelContainer) as WordStorageModelContextType }
+        // One shared main context for the app's lifetime: the writer and any reader operate on the same
+        // `ModelContext` over `sharedModelContainer`, so an insert is immediately visible to a fetch and
+        // there is a single stable identity (`===` in `DependencyGraphTests`).
+        register(in: .container) { _ in ModelContext(sharedModelContainer) as WordStorageModelContextType }
 
         register(in: .container) { container in
             PlayedWordsLibrary(wordContext: container.resolve()) as PlayedWordsLibraryType

--- a/Worday/Storage/WordStorageModelContext.swift
+++ b/Worday/Storage/WordStorageModelContext.swift
@@ -1,7 +1,7 @@
 import SwiftData
 import Foundation
 
-protocol WordStorageModelContextType {
+protocol WordStorageModelContextType: AnyObject {
     func insert(_ model: WordStorageEntity)
     func save() throws
     func fetchAll() throws -> [WordStorageEntity]

--- a/WordayTests/Mocks/Storage/PlayedWordsLibraryMock.swift
+++ b/WordayTests/Mocks/Storage/PlayedWordsLibraryMock.swift
@@ -3,15 +3,10 @@
 final class PlayedWordsLibraryMock: PlayedWordsLibraryType {
 
     enum Call: Equatable {
-        case load
         case reload
     }
 
     var words: [WordStorageEntity] = []
-
-    func load() {
-        calls.append(.load)
-    }
 
     func reload() {
         calls.append(.reload)

--- a/WordayTests/Mocks/Storage/WordStorageModelContextMock.swift
+++ b/WordayTests/Mocks/Storage/WordStorageModelContextMock.swift
@@ -10,6 +10,8 @@ final class WordStorageModelContextMock: WordStorageModelContextType {
         case fetchAll
         case fetch
     }
+
+    enum StubError: Error { case failed }
     
     func insert(_ model: WordStorageEntity) {
         calls.append(.insert(model: model))
@@ -21,14 +23,17 @@ final class WordStorageModelContextMock: WordStorageModelContextType {
     
     func fetchAll() throws -> [WordStorageEntity] {
         calls.append(.fetchAll)
+        if let fetchAllThrows { throw fetchAllThrows }
         return fetchReturnValue
     }
-    
+
     func fetch(_ descriptor: FetchDescriptor<WordStorageEntity>) throws -> [WordStorageEntity] {
         calls.append(.fetch)
+        if let fetchAllThrows { throw fetchAllThrows }
         return fetchReturnValue
     }
-    
+
     var calls: [Call] = []
     var fetchReturnValue: [WordStorageEntity] = []
+    var fetchAllThrows: Error?
 }

--- a/WordayTests/Tests/Common/Dependency Injection/DependencyGraphTests.swift
+++ b/WordayTests/Tests/Common/Dependency Injection/DependencyGraphTests.swift
@@ -67,6 +67,16 @@ struct DependencyGraphTests {
         #expect(first === second)
     }
 
+    @Test("the shared model context resolves to the same instance")
+    func modelContextIsShared() {
+        let container = makeWiredContainer()
+
+        let first = container.resolve() as WordStorageModelContextType
+        let second = container.resolve() as WordStorageModelContextType
+
+        #expect(first === second)
+    }
+
     // MARK: - Privates
 
     private func makeWiredContainer() -> ContainerType {

--- a/WordayTests/Tests/Storage/PlayedWordsLibraryTests.swift
+++ b/WordayTests/Tests/Storage/PlayedWordsLibraryTests.swift
@@ -11,13 +11,13 @@ struct PlayedWordsLibraryTests {
         sut = .init(wordContext: mockWordContext)
     }
 
-    @Test("load reads the stored words from the context")
-    func loadReadsFromStore() {
+    @Test("reload reads the stored words from the context")
+    func reloadReadsFromStore() {
         mockWordContext.fetchReturnValue = [
             .init(id: .init(rawValue: "1"), word: "CAT", playedAt: .init(timeIntervalSince1970: 0))
         ]
 
-        sut.load()
+        sut.reload()
 
         #expect(sut.words.map(\.word) == ["CAT"])
         #expect(mockWordContext.calls == [.fetchAll])
@@ -26,7 +26,7 @@ struct PlayedWordsLibraryTests {
     @Test("reload refreshes the words from the context")
     func reloadRefreshesFromStore() {
         mockWordContext.fetchReturnValue = []
-        sut.load()
+        sut.reload()
         #expect(sut.words.isEmpty)
 
         mockWordContext.fetchReturnValue = [
@@ -35,5 +35,20 @@ struct PlayedWordsLibraryTests {
         sut.reload()
 
         #expect(sut.words.map(\.word) == ["DOG"])
+    }
+
+    @Test("reload keeps the last-known-good words when the fetch fails")
+    func reloadKeepsLastKnownGoodOnError() {
+        mockWordContext.fetchReturnValue = [
+            .init(id: .init(rawValue: "1"), word: "CAT", playedAt: .init(timeIntervalSince1970: 0))
+        ]
+        sut.reload()
+        #expect(sut.words.map(\.word) == ["CAT"])
+
+        mockWordContext.fetchAllThrows = WordStorageModelContextMock.StubError.failed
+        sut.reload()
+
+        // The transient read error must not blank the history the UI is showing.
+        #expect(sut.words.map(\.word) == ["CAT"])
     }
 }

--- a/WordayTests/Tests/Storage/Schema/WordStorageMigrationTests.swift
+++ b/WordayTests/Tests/Storage/Schema/WordStorageMigrationTests.swift
@@ -10,8 +10,7 @@ struct WordStorageMigrationTests {
 
     @Test("a V1 (String id) store migrates to V2 (EntityID) preserving word, date, and id")
     func migratesV1StoreToV2() throws {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("worday-migration-test-\(UUID().uuidString).store")
+        let url = makeStoreURL()
         defer { removeStore(at: url) }
 
         let playedAt = Date(timeIntervalSince1970: 1_000)
@@ -22,14 +21,7 @@ struct WordStorageMigrationTests {
         }
 
         // 2. Open the same store with the current schema + migration plan.
-        let v2Schema = Schema(versionedSchema: WordStorageSchemaV2.self)
-        let v2Container = try ModelContainer(
-            for: v2Schema,
-            migrationPlan: WordStorageMigrationPlan.self,
-            configurations: ModelConfiguration(schema: v2Schema, url: url)
-        )
-        let context = ModelContext(v2Container)
-        let rows = try context.fetch(FetchDescriptor<WordStorageEntity>())
+        let rows = try openV2AndFetch(at: url)
 
         // 3. Every field survived, and the id is now the wrapped EntityID.
         #expect(rows.count == 1)
@@ -38,7 +30,52 @@ struct WordStorageMigrationTests {
         #expect(rows.first?.id == EntityID(rawValue: "uuid-123"))
     }
 
+    @Test("an empty V1 store migrates to an empty V2 store")
+    func migratesEmptyV1Store() throws {
+        let url = makeStoreURL()
+        defer { removeStore(at: url) }
+
+        try writeV1Store(at: url) { _ in }
+
+        let rows = try openV2AndFetch(at: url)
+
+        #expect(rows.isEmpty)
+    }
+
+    @Test("a multi-row V1 store migrates carrying every row forward")
+    func migratesMultiRowV1Store() throws {
+        let url = makeStoreURL()
+        defer { removeStore(at: url) }
+
+        let seed: [(id: String, word: String, playedAt: Date)] = [
+            (id: "1", word: "CAT", playedAt: Date(timeIntervalSince1970: 1_000)),
+            (id: "2", word: "DOG", playedAt: Date(timeIntervalSince1970: 2_000)),
+            (id: "3", word: "FOX", playedAt: Date(timeIntervalSince1970: 3_000))
+        ]
+
+        try writeV1Store(at: url) { context in
+            for row in seed {
+                context.insert(WordStorageSchemaV1.WordStorageEntity(id: row.id, word: row.word, playedAt: row.playedAt))
+            }
+        }
+
+        let rows = try openV2AndFetch(at: url)
+
+        #expect(rows.count == seed.count)
+        // Every seeded row survived with its id, word, and date — compared order-independently.
+        for row in seed {
+            let match = rows.first { $0.id == EntityID(rawValue: row.id) }
+            #expect(match?.word == row.word)
+            #expect(match?.playedAt == row.playedAt)
+        }
+    }
+
     // MARK: - Helpers
+
+    private func makeStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("worday-migration-test-\(UUID().uuidString).store")
+    }
 
     private func writeV1Store(at url: URL, _ insert: (ModelContext) -> Void) throws {
         let v1Schema = Schema(versionedSchema: WordStorageSchemaV1.self)
@@ -49,6 +86,16 @@ struct WordStorageMigrationTests {
         let context = ModelContext(container)
         insert(context)
         try context.save()
+    }
+
+    private func openV2AndFetch(at url: URL) throws -> [WordStorageEntity] {
+        let v2Schema = Schema(versionedSchema: WordStorageSchemaV2.self)
+        let v2Container = try ModelContainer(
+            for: v2Schema,
+            migrationPlan: WordStorageMigrationPlan.self,
+            configurations: ModelConfiguration(schema: v2Schema, url: url)
+        )
+        return try ModelContext(v2Container).fetch(FetchDescriptor<WordStorageEntity>())
     }
 
     private func removeStore(at url: URL) {


### PR DESCRIPTION
Follow-up to the [WRD-48] Storage review — six targeted fixes, **no behavioural change** to the game loop. Each maps to a review finding.

## Fixes
1. **Share one `ModelContext`** — `WordStorageModelContextType` is now registered `.container` (protocol made class-bound), so the writer (`WordProviderUseCase`) and every reader (`PlayedWordsLibrary`) operate on the **same** context over `sharedModelContainer` — an insert is immediately visible to a fetch, with a single stable identity. `DependencyGraphTests` asserts `===`. (was `.default` → a fresh context per resolve)
2. **Keep last-known-good on read failure** — `PlayedWordsLibrary.reload()` no longer blanks `words` when `fetchAll()` throws; the data is safe on disk, so a transient read error must not empty the history the UI shows. New test `reloadKeepsLastKnownGoodOnError`.
3. **Actionable crash log** — `sharedModelContainer`'s `fatalError` now interpolates the underlying `error`.
4. **Migration atomicity note** — documented in `WordStorageMigrationPlan` that `willMigrate`/`didMigrate` must run in one pass (the drain-empty-refill tradeoff for a non-mappable type change).
5. **More migration coverage** — added empty-store and multi-row cases to `WordStorageMigrationTests`.
6. **Collapse redundant `load()`/`reload()`** — the projection had two methods with identical bodies; now a single `reload()` (launch hydration calls it too).

## Docs
- CLAUDE.md — persistence + Shared Store Projections sections updated (`.container` context, single `reload()`, keep-last-known-good).
- `Storage.md` — same.

## Testing
- `xcodebuild test` — **`** TEST SUCCEEDED **`**, **83 tests** (79 + 4 new), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)