### PR TITLE
[WRD-53] Tokenise remaining system text styles into DSFont

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,9 +642,10 @@ radius, or font in a view; reach for a semantic token or a `DS*` component. Full
   tracking). It resolves through `DSFontFamily` (the raw faces: `display`=Baskerville, `chrome`=Copperplate,
   `impact`, `mono`=system-monospaced, `ui`=system). **Content roles are clean system sans** (matching the
   result screen); serif is reserved for display titles. **Every feature uses `.dsFont(_:)`** — the old
-  `wdFont*`/`titleFont`/`bodyFont` constants are gone; never use `.font(.system(...))`/`.custom(...)` in a
-  feature. (System text styles like `.font(.caption)` still appear on a few screens; convert to a `DSFont`
-  role when you touch them.)
+  `wdFont*`/`titleFont`/`bodyFont` constants are gone, and raw `.font(.caption)`/`.footnote`/… have been
+  tokenised too; never use `.font(.system(...))`/`.custom(...)`/`.font(.<textStyle>)` in a feature. Content
+  roles (`.sectionTitle`/`.callout`/`.footnote`/`.caption`/`.caption2`/`.keyCap`) resolve to **system text
+  styles**, so they scale with Dynamic Type; brand faces and gameplay tiles are fixed-size.
 - **Colors** — `DSColor` is the semantic layer (`textPrimary`, `textSecondary`, `background`, `border`,
   `brand`, `link`, `correct`, …); it aliases `DSPalette`, the raw layer over the asset colorsets. **Links
   wear `DSColor.link` (the cardinal brand red), never system blue.** The pre-DS `ColorTokens` `Color.*`

--- a/Worday/Design System/DesignSystem.md
+++ b/Worday/Design System/DesignSystem.md
@@ -32,13 +32,14 @@ Text("Dictionary data").dsFont(.sectionTitle)
 
 Roles resolve through `DSFontFamily`, the raw faces and the single swap point:
 `display` = Baskerville · `chrome` = Copperplate · `impact` = Impact · `mono` = system monospaced ·
-`ui` = system sans. **Content roles (`sectionTitle`, `callout`, `caption`) are clean system sans** — the
-Copperplate engraved face is display-only, never body copy. Display serif is `largeTitle`/`title`
-(Baskerville); the gameplay tiles/counters are `gameTile`/`gameHeading`/`gameTitle`/`gameCaption` (mono).
+`ui` = system sans. **Content roles (`sectionTitle`, `callout`, `footnote`, `caption`, `caption2`,
+`keyCap`) resolve to system text styles and scale with Dynamic Type** — the Copperplate engraved face is
+display-only, never body copy. Display serif is `largeTitle`/`title` (Baskerville, fixed); the gameplay
+tiles are `gameTile` (mono, fixed) — anything size-critical stays fixed.
 
-Every feature uses `.dsFont(_:)` — the pre-DS `wdFont*`/`titleFont`/`bodyFont` constants have been
-removed. (A few screens still use raw system text styles like `.font(.caption)`; convert those to a
-`DSFont` role when touched.)
+Every feature uses `.dsFont(_:)` — the pre-DS `wdFont*`/`titleFont`/`bodyFont` constants **and** raw
+`.font(.caption)`/`.footnote`/… have all been removed. `DSFont` is the single source of every font in the
+app.
 
 ### Colours — `DSColor` (→ `DSPalette`)
 `DSColor` is the semantic layer features use (`textPrimary`, `textSecondary`, `background`, `border`,

--- a/Worday/Design System/Foundations/Typography/DSFont.swift
+++ b/Worday/Design System/Foundations/Typography/DSFont.swift
@@ -1,67 +1,74 @@
 import SwiftUI
 
-/// The semantic type scale — the tier features use. Each role names a *purpose* and resolves to a
-/// `DSFontFamily` + size + weight + tracking, so screens ask for `.dsFont(.sectionTitle)`, never a raw
-/// `.system(size:)`/`.custom(...)`. Mirrors the two-tier typography architecture (raw faces → roles).
+/// The semantic type scale — the tier features use. Each role names a *purpose* and resolves to either a
+/// fixed-size brand face (`DSFontFamily`) or a system text style (Dynamic-Type-scaled), so screens ask for
+/// `.dsFont(.sectionTitle)`, never a raw `.system(size:)`/`.custom(...)`/`.font(.caption)`.
+///
+/// Display titles, the wordmark serif, the Impact face, and the gameplay tiles are **fixed** (their
+/// layout is size-critical); content/label roles ride the **system text styles** so body copy scales for
+/// accessibility and reads like the result screen.
 enum DSFont: CaseIterable {
 
-    // Display serif (Baskerville)
+    // Display serif (Baskerville) — fixed
     case largeTitle        // hero title / streak headline
     case title             // screen title
 
-    // Content (system sans — clean and legible, matching the result screen)
+    // Content (system text styles — Dynamic Type)
     case sectionTitle      // grouped-section heading
+    case keyCap            // keyboard letter key
     case callout           // body copy
+    case footnote          // compact stat / label
     case caption           // footnotes, version string
+    case caption2          // smallest label
 
-    // Chrome serif (Copperplate)
+    // Chrome serif (Copperplate) — fixed
     case body              // engraved-serif body copy (game chrome, meaning screen)
 
-    // Impact
+    // Impact — fixed
     case impact            // loud display moment
 
-    // Mono (gameplay & interface)
+    // Mono gameplay — fixed
     case gameTile          // the scrambled letter tiles
-    case gameHeading       // large mono heading
-    case gameTitle         // mono title
-    case gameCaption       // micro mono caption
 
-    // System (compact interface labels)
-    case label
-    case labelSmall
+    // System label — fixed
+    case label             // compact interface label (buttons)
 
     // MARK: - Publics
 
-    /// The resolved SwiftUI font (scales with Dynamic Type for the custom faces).
-    var font: Font { spec.family.font(size: spec.size, weight: spec.weight) }
+    /// The resolved SwiftUI font. Content roles scale with Dynamic Type; brand/gameplay roles are fixed.
+    var font: Font {
+        switch resolution {
+        case let .face(family, size, weight):
+            family.font(size: size, weight: weight)
+        case let .textStyle(style, weight):
+            .system(style, weight: weight)
+        }
+    }
 
-    /// Letter spacing that pairs with this role. Applied together with `font` by `.dsFont(_:)`.
-    var tracking: CGFloat { spec.tracking }
+    /// Letter spacing paired with this role (applied with `font` by `.dsFont(_:)`).
+    var tracking: CGFloat { 0 }
 
     // MARK: - Privates
 
-    private struct Spec {
-        let family: DSFontFamily
-        let size: CGFloat
-        var weight: Font.Weight = .regular
-        var tracking: CGFloat = 0
+    private enum Resolution {
+        case face(DSFontFamily, size: CGFloat, weight: Font.Weight)
+        case textStyle(Font.TextStyle, weight: Font.Weight)
     }
 
-    private var spec: Spec {
+    private var resolution: Resolution {
         switch self {
-        case .largeTitle:   Spec(family: .display, size: 42)
-        case .title:        Spec(family: .display, size: 32)
-        case .sectionTitle: Spec(family: .ui, size: 20, weight: .semibold)
-        case .callout:      Spec(family: .ui, size: 16)
-        case .caption:      Spec(family: .ui, size: 13)
-        case .body:         Spec(family: .chrome, size: 18)
-        case .impact:       Spec(family: .impact, size: 36)
-        case .gameTile:     Spec(family: .mono, size: 36, weight: .medium)
-        case .gameHeading:  Spec(family: .mono, size: 24, weight: .medium)
-        case .gameTitle:    Spec(family: .mono, size: 20, weight: .medium)
-        case .gameCaption:  Spec(family: .mono, size: 8, weight: .medium)
-        case .label:        Spec(family: .ui, size: 16)
-        case .labelSmall:   Spec(family: .ui, size: 12)
+        case .largeTitle:   .face(.display, size: 42, weight: .regular)
+        case .title:        .face(.display, size: 32, weight: .regular)
+        case .sectionTitle: .textStyle(.title3, weight: .semibold)
+        case .keyCap:       .textStyle(.title3, weight: .regular)
+        case .callout:      .textStyle(.callout, weight: .regular)
+        case .footnote:     .textStyle(.footnote, weight: .regular)
+        case .caption:      .textStyle(.caption, weight: .regular)
+        case .caption2:     .textStyle(.caption2, weight: .regular)
+        case .body:         .face(.chrome, size: 18, weight: .regular)
+        case .impact:       .face(.impact, size: 36, weight: .regular)
+        case .gameTile:     .face(.mono, size: 36, weight: .medium)
+        case .label:        .face(.ui, size: 16, weight: .regular)
         }
     }
 }

--- a/Worday/Views/Finished/FinishedGameView.swift
+++ b/Worday/Views/Finished/FinishedGameView.swift
@@ -35,13 +35,13 @@ struct FinishedGameView: View {
             VStack(spacing: .space_4pt) {
                 Text(viewState.scoreString)
                     .multilineTextAlignment(.center)
-                    .font(.caption)
+                    .dsFont(.caption)
                     .bold()
                     .animation(nil, value: viewState)
                 
                 Text(viewState.subtitle)
                     .multilineTextAlignment(.center)
-                    .font(.caption)
+                    .dsFont(.caption)
                     .bold()
                     .animation(nil, value: viewState)
             }
@@ -50,12 +50,12 @@ struct FinishedGameView: View {
                 VStack {
                     Text("\(viewState.totalPlayed.value)")
                         .multilineTextAlignment(.center)
-                        .font(.footnote)
+                        .dsFont(.footnote)
                         .bold()
                         .foregroundStyle(Color.orange)
                     Text(viewState.totalPlayed.title)
                         .multilineTextAlignment(.center)
-                        .font(.footnote)
+                        .dsFont(.footnote)
                         .bold()
                 }
                 Spacer()
@@ -63,12 +63,12 @@ struct FinishedGameView: View {
                 VStack {
                     Text("\(viewState.currentStreak.value)")
                         .multilineTextAlignment(.center)
-                        .font(.footnote)
+                        .dsFont(.footnote)
                         .bold()
                         .foregroundStyle(Color.orange)
                     Text(viewState.currentStreak.title)
                         .multilineTextAlignment(.center)
-                        .font(.footnote)
+                        .dsFont(.footnote)
                         .bold()
                 }
             }
@@ -144,7 +144,7 @@ struct FinishedGameView: View {
                                         .bold()
                                     
                                     Text(def.definition)
-                                        .font(.callout)
+                                        .dsFont(.callout)
                                     Spacer()
                                 }
                                 .padding([.horizontal], .space_32pt)

--- a/Worday/Views/Ongoing/KeyboardView.swift
+++ b/Worday/Views/Ongoing/KeyboardView.swift
@@ -24,7 +24,7 @@ struct KeyBoardView: View {
             viewState.onTapEnter.action()
         } label: {
             Text("ENTER")
-                .font(.caption2)
+                .dsFont(.caption2)
                 .fontWeight(.bold)
                 .scaledToFill()
                 .minimumScaleFactor(0.01)
@@ -55,7 +55,7 @@ struct KeyBoardView: View {
             vs.onTap.action()
         } label: {
             Text(vs.character.uppercased())
-                .font(.title3)
+                .dsFont(.keyCap)
                 .fontWeight(.bold)
                 .foregroundColor(DSColor.textPrimary)
                 .frame(width: .size_48pt, height: .size_48pt)

--- a/Worday/Views/Word List/WordListView.swift
+++ b/Worday/Views/Word List/WordListView.swift
@@ -32,10 +32,10 @@ struct WordListView: View {
                     .dsFont(.title)
                 
                 Text(card.dateSection.title)
-                    .font(.caption)
+                    .dsFont(.caption)
                 
                 Text(card.dateSection.date, style: .date)
-                    .font(.caption)
+                    .dsFont(.caption)
                 
             }
             .padding(.space_12pt)

--- a/Worday/Views/Word Meaning/WordMeaningView.swift
+++ b/Worday/Views/Word Meaning/WordMeaningView.swift
@@ -80,7 +80,7 @@ struct WordMeaningView: View {
                                         .bold()
                                     
                                     Text(def.definition)
-                                        .font(.callout)
+                                        .dsFont(.callout)
                                     Spacer()
                                 }
                                 .padding([.horizontal], .space_32pt)


### PR DESCRIPTION
## What & why
The DS-adoption work (WRD-52) left a handful of screens using raw SwiftUI text styles (`.font(.caption)`/`.footnote`/`.callout`/`.caption2`/`.title3`). This routes those through `DSFont` too, so **`DSFont` is the single source of every font in the app**.

## Changes
- **`DSFont` gains a two-tier resolution:** brand faces (Baskerville/Copperplate/Impact) and the gameplay tiles (mono) stay **fixed-size**; content roles resolve to **system text styles** (Dynamic Type):
  - `sectionTitle` → `.title3` semibold · `keyCap` → `.title3` · `callout` → `.callout` · `footnote` → `.footnote` · `caption` → `.caption` · `caption2` → `.caption2`.
- **Converted** the remaining `.font(.<style>)` usages in Keyboard, Word List, Finished, and Word Meaning to the matching roles.
- **Dropped** the dead `gameHeading`/`gameTitle`/`gameCaption`/`labelSmall` roles (only reachable via the removed `WDFont` aliases).

## Impact
Each new role maps to the **exact** system style it replaced, so the game/list/finished/meaning conversions are pixel-identical **and** content type now scales with Dynamic Type. The Info/Ack content roles move from fixed sizes to the matching Dynamic-Type styles — same look at the default text size, now scalable. Build + full suite green; game screen verified identical.

Docs updated (CLAUDE.md, `DesignSystem.md`, memory): `DSFont` is now the sole font source; nothing in a feature uses `.font(...)` with a system style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)